### PR TITLE
Add `ArrayN::zip{3,4,5}_with`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,10 +234,10 @@ impl<T, const N: usize> Array<T> for [T; N] {
 
 /// Array with size information on the type.
 pub trait ArrayN<T, const N: usize>: Array<T> {
-    /// Merges elements with another array by calling a `FnMut(T, U) -> V` closure for each pair.
-    fn zip_with<U, V, F>(self, other: [U; N], f: F) -> [V; N]
+    /// Merges elements with another array by calling a `FnMut(T, U) -> Output` closure for each pair.
+    fn zip_with<U, Output, F>(self, other: [U; N], f: F) -> [Output; N]
     where
-        F: FnMut(T, U) -> V,
+        F: FnMut(T, U) -> Output,
         Self: Sized;
 
     /// Converts this object into it's concrete array type.
@@ -264,9 +264,9 @@ pub trait ArrayN<T, const N: usize>: Array<T> {
 
 impl<T, const N: usize> ArrayN<T, N> for [T; N] {
     #[inline]
-    fn zip_with<U, V, F>(self, other: [U; N], mut f: F) -> [V; N]
+    fn zip_with<U, Output, F>(self, other: [U; N], mut f: F) -> [Output; N]
     where
-        F: FnMut(T, U) -> V,
+        F: FnMut(T, U) -> Output,
     {
         let mut b = other.into_iter();
         self.map(|a| f(a, b.next().unwrap()))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,6 +240,26 @@ pub trait ArrayN<T, const N: usize>: Array<T> {
         F: FnMut(T, U) -> Output,
         Self: Sized;
 
+    /// Merges elements with another two arrays by calling a `FnMut(T, U, V) -> Output` closure for each tuple.
+    fn zip3_with<U, V, Output, F>(self, other1: [U; N], other2: [V; N], f: F) -> [Output; N]
+    where
+        F: FnMut(T, U, V) -> Output,
+        Self: Sized;
+
+    /// Merges elements with another three arrays by calling a `FnMut(T, U, V, W) -> Output` closure for each tuple.
+    fn zip4_with<U, V, W, Output, F>(self, other1: [U; N], other2: [V; N], other3: [W; N], f: F) -> [Output; N]
+    where
+        F: FnMut(T, U, V, W) -> Output,
+        Self: Sized;
+
+    /// Merges elements with another four arrays by calling a `FnMut(T, U, V, W, X) -> Output` closure for each tuple.
+    fn zip5_with<U, V, W, X, Output, F>(
+        self, other1: [U; N], other2: [V; N], other3: [W; N], other4: [X; N], f: F,
+    ) -> [Output; N]
+    where
+        F: FnMut(T, U, V, W, X) -> Output,
+        Self: Sized;
+
     /// Converts this object into it's concrete array type.
     fn downcast(self) -> [T; N];
 
@@ -270,6 +290,49 @@ impl<T, const N: usize> ArrayN<T, N> for [T; N] {
     {
         let mut b = other.into_iter();
         self.map(|a| f(a, b.next().unwrap()))
+    }
+
+    #[inline]
+    fn zip3_with<U, V, Output, F>(self, other1: [U; N], other2: [V; N], mut f: F) -> [Output; N]
+    where
+        F: FnMut(T, U, V) -> Output,
+    {
+        let mut it1 = other1.into_iter();
+        let mut it2 = other2.into_iter();
+        self.map(|x0| f(x0, it1.next().unwrap(), it2.next().unwrap()))
+    }
+
+    #[inline]
+    fn zip4_with<U, V, W, Output, F>(self, other1: [U; N], other2: [V; N], other3: [W; N], mut f: F) -> [Output; N]
+    where
+        F: FnMut(T, U, V, W) -> Output,
+    {
+        let mut it1 = other1.into_iter();
+        let mut it2 = other2.into_iter();
+        let mut it3 = other3.into_iter();
+        self.map(|x0| f(x0, it1.next().unwrap(), it2.next().unwrap(), it3.next().unwrap()))
+    }
+
+    #[inline]
+    fn zip5_with<U, V, W, X, Output, F>(
+        self, other1: [U; N], other2: [V; N], other3: [W; N], other4: [X; N], mut f: F,
+    ) -> [Output; N]
+    where
+        F: FnMut(T, U, V, W, X) -> Output,
+    {
+        let mut it1 = other1.into_iter();
+        let mut it2 = other2.into_iter();
+        let mut it3 = other3.into_iter();
+        let mut it4 = other4.into_iter();
+        self.map(|x0| {
+            f(
+                x0,
+                it1.next().unwrap(),
+                it2.next().unwrap(),
+                it3.next().unwrap(),
+                it4.next().unwrap(),
+            )
+        })
     }
 
     #[inline]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -157,7 +157,30 @@ fn non_copy() {
     assert_eq!(arr.clone().foldl(0, |a, n| a + n.0), 6);
 
     let arr2 = [Test(10), Test(20), Test(30)];
-    assert_eq!(arr.zip_with(arr2, |a, b| a.0 + b.0), [11, 22, 33]);
+    assert_eq!(arr.clone().zip_with(arr2.clone(), |a, b| a.0 + b.0), [11, 22, 33]);
+
+    let arr3 = [Test(100), Test(200), Test(300)];
+    assert_eq!(
+        arr.clone()
+            .zip3_with(arr2.clone(), arr3.clone(), |a, b, c| a.0 + b.0 + c.0),
+        [111, 222, 333]
+    );
+
+    let arr4 = [Test(1000), Test(2000), Test(3000)];
+    assert_eq!(
+        arr.clone()
+            .zip4_with(arr2.clone(), arr3.clone(), arr4.clone(), |a, b, c, d| a.0
+                + b.0
+                + c.0
+                + d.0),
+        [1111, 2222, 3333]
+    );
+
+    let arr5 = [Test(10000), Test(20000), Test(30000)];
+    assert_eq!(
+        arr.zip5_with(arr2, arr3, arr4, arr5, |a, b, c, d, e| a.0 + b.0 + c.0 + d.0 + e.0),
+        [11111, 22222, 33333]
+    );
 }
 
 #[test]


### PR DESCRIPTION
This PR proposes to add the following methods to the `ArrayN` trait:

```rust
pub trait ArrayN<T, const N: usize>: Array<T> {
    fn zip3_with<U, V, Output, F>(self, other1: [U; N], other2: [V; N], f: F) -> [Output; N]
    where
        F: FnMut(T, U, V) -> Output,
        Self: Sized;

    fn zip4_with<U, V, W, Output, F>(self, other1: [U; N], other2: [V; N], other3: [W; N], f: F) -> [Output; N]
    where
        F: FnMut(T, U, V, W) -> Output,
        Self: Sized;

    fn zip5_with<U, V, W, X, Output, F>(
        self, other1: [U; N], other2: [V; N], other3: [W; N], other4: [X; N], f: F,
    ) -> [Output; N]
    where
        F: FnMut(T, U, V, W, X) -> Output,
        Self: Sized;
}
```